### PR TITLE
[SIG-2161] Image endpoint config

### DIFF
--- a/domains/amsterdam/acc.config.json
+++ b/domains/amsterdam/acc.config.json
@@ -93,7 +93,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",

--- a/domains/amsterdam/prod.config.json
+++ b/domains/amsterdam/prod.config.json
@@ -109,7 +109,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",

--- a/domains/amsterdamsebos/acc.config.json
+++ b/domains/amsterdamsebos/acc.config.json
@@ -93,7 +93,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",

--- a/domains/amsterdamsebos/prod.config.json
+++ b/domains/amsterdamsebos/prod.config.json
@@ -93,7 +93,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",

--- a/domains/weesp/acc.config.json
+++ b/domains/weesp/acc.config.json
@@ -90,7 +90,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",

--- a/domains/weesp/prod.config.json
+++ b/domains/weesp/prod.config.json
@@ -90,7 +90,6 @@
   "CATEGORIES_PRIVATE_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/categories/",
   "CATEGORIES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/terms/categories/",
   "TERMS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/terms/categories/",
-  "IMAGE_ENDPOINT": "https://api.data.amsterdam.nl/signals/signal/image/",
   "FILTERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/me/filters/",
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",


### PR DESCRIPTION
This PR removes the `IMAGE_ENDPOINT` config prop for all domains.
See https://github.com/Amsterdam/signals-frontend/pull/1104 for reference