### PR TITLE
(Chore) Add areas endpoint

### DIFF
--- a/domains/amsterdam/acc.config.json
+++ b/domains/amsterdam/acc.config.json
@@ -77,6 +77,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/",

--- a/domains/amsterdam/prod.config.json
+++ b/domains/amsterdam/prod.config.json
@@ -93,6 +93,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/permissions/",
@@ -112,5 +113,5 @@
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
   "OVL_VERLICHTING_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Verlichting&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
-  "QUESTIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/questions/"
+  "QUESTIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/questions/"
 }

--- a/domains/amsterdamsebos/acc.config.json
+++ b/domains/amsterdamsebos/acc.config.json
@@ -77,6 +77,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/",

--- a/domains/amsterdamsebos/prod.config.json
+++ b/domains/amsterdamsebos/prod.config.json
@@ -77,6 +77,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/permissions/",
@@ -96,5 +97,5 @@
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
   "OVL_VERLICHTING_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Verlichting&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
-  "QUESTIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/questions/"
+  "QUESTIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/questions/"
 }

--- a/domains/weesp/acc.config.json
+++ b/domains/weesp/acc.config.json
@@ -74,6 +74,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/",

--- a/domains/weesp/prod.config.json
+++ b/domains/weesp/prod.config.json
@@ -74,6 +74,7 @@
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
+  "AREAS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/areas/",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/permissions/",
@@ -93,5 +94,5 @@
   "DEPARTMENTS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/departments/",
   "OVL_KLOKKEN_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
   "OVL_VERLICHTING_LAYER": "https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Verlichting&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326",
-  "QUESTIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/questions/"
+  "QUESTIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/public/questions/"
 }


### PR DESCRIPTION
This PR adds the `AREAS_ENDPOINT` config prop for all domains.
It also contains a fix for one the URLs in the production configs for all domains.