### PR TITLE
[SIG-3301] Fix the Weesp logo text and the url

### DIFF
--- a/domains/weesp/acc.config.json
+++ b/domains/weesp/acc.config.json
@@ -10,7 +10,7 @@
     "siteTitle": "Meldingen Weesp",
     "title": "Meldingen Weesp",
     "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391.",
-    "logoDescription": "Logo gemeente Weesp, naar amsterdam.nl"
+    "logoDescription": "Logo gemeente Weesp, naar weesp.nl"
   },
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
   "links": {

--- a/domains/weesp/acc.config.json
+++ b/domains/weesp/acc.config.json
@@ -9,9 +9,13 @@
     "siteAddress": "meldingenweesp.amsterdam.nl",
     "siteTitle": "Meldingen Weesp",
     "title": "Meldingen Weesp",
-    "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391."
+    "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391.",
+    "logoDescription": "Logo gemeente Weesp, naar amsterdam.nl"
   },
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
+  "links": {
+    "home": "https://www.weesp.nl"
+  },
   "logo": {
     "url": "/assets/logos/logo-weesp.svg",
     "width": "297px",

--- a/domains/weesp/prod.config.json
+++ b/domains/weesp/prod.config.json
@@ -10,7 +10,7 @@
     "siteTitle": "Meldingen Weesp",
     "title": "Meldingen Weesp",
     "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391.",
-    "logoDescription": "Logo gemeente Weesp, naar amsterdam.nl"
+    "logoDescription": "Logo gemeente Weesp, naar weesp.nl"
   },
   "apiBaseUrl": "https://api.data.amsterdam.nl",
   "links": {

--- a/domains/weesp/prod.config.json
+++ b/domains/weesp/prod.config.json
@@ -9,9 +9,13 @@
     "siteAddress": "meldingenweesp.amsterdam.nl",
     "siteTitle": "Meldingen Weesp",
     "title": "Meldingen Weesp",
-    "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391."
+    "urgentContactInfo": "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met (0294) 491 391.",
+    "logoDescription": "Logo gemeente Weesp, naar amsterdam.nl"
   },
   "apiBaseUrl": "https://api.data.amsterdam.nl",
+  "links": {
+    "home": "https://www.weesp.nl"
+  },
   "logo": {
     "url": "/assets/logos/logo-weesp.svg",
     "width": "297px",


### PR DESCRIPTION
This PR fixes, in the Weesp configuration, @the logo description for screen readers and the home url