### PR TITLE
[SIG-3095] Add DOCKER_IMAGE_TAG variable

### DIFF
--- a/Jenkinsfile.acceptance
+++ b/Jenkinsfile.acceptance
@@ -11,6 +11,7 @@ signalenAcceptancePipeline {
   SIGNALEN_REPOSITORY = 'Amsterdam/signalen' // The signalen mono repository
   SIGNALS_FRONTEND_REPOSITORY = 'Amsterdam/signals-frontend' // The front-end repository
   DOCKER_BUILD_ARG_REGISTRY_HOST = 'docker-registry.data.amsterdam.nl' // Used as Dockerfile ARG
+  DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG = 'latest' // Used as Dockerfile ARG
   SLACK_NOTIFICATIONS_CHANNEL = '#ci-signalen' // Build events will be posted to this channel
   JENKINS_NODE = 'BS16 || BS17' // Jenkins client which will run this pipeline
   DOCKER_REGISTRY_AUTH = 'docker_registry_auth' // docker_registry_auth is the ID of a global Jenkins secret

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -9,6 +9,7 @@ signalenReleasePipeline {
   SIGNALEN_REPOSITORY = 'Amsterdam/signalen' // The signalen mono repository
   SIGNALS_FRONTEND_REPOSITORY = 'Amsterdam/signals-frontend' // The front-end repository
   DOCKER_BUILD_ARG_REGISTRY_HOST = 'docker-registry.data.amsterdam.nl' // Used as Dockerfile ARG
+  DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG = 'latest' // Used as Dockerfile ARG
   SLACK_NOTIFICATIONS_CHANNEL = '#ci-signalen' // Build events will be posted to this channel
   JENKINS_NODE = 'BS16 || BS17' // Jenkins client which will run this pipeline
   DOCKER_REGISTRY_AUTH = 'docker_registry_auth' // docker_registry_auth is the ID of a global Jenkins secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       args:
         - BUILD_ENV=acc
         - DOCKER_REGISTRY=docker-registry.data.amsterdam.nl:5000
-        - DOCKER_REGISTRY_PATH=/ois/
-        - DOCKER_IMAGE=signalsfrontend
         - DOCKER_IMAGE_TAG=latest
     environment:
       - TZ=Europe/Amsterdam
@@ -21,8 +19,6 @@ services:
       args:
         - BUILD_ENV=acc
         - DOCKER_REGISTRY=docker-registry.data.amsterdam.nl:5000
-        - DOCKER_REGISTRY_PATH=/ois/
-        - DOCKER_IMAGE=signalsfrontend
         - DOCKER_IMAGE_TAG=latest
     environment:
       - TZ=Europe/Amsterdam
@@ -35,8 +31,6 @@ services:
       args:
         - BUILD_ENV=acc
         - DOCKER_REGISTRY=docker-registry.data.amsterdam.nl:5000
-        - DOCKER_REGISTRY_PATH=/ois/
-        - DOCKER_IMAGE=signalsfrontend
         - DOCKER_IMAGE_TAG=latest
     environment:
       - TZ=Europe/Amsterdam

--- a/domains/amsterdam/Dockerfile
+++ b/domains/amsterdam/Dockerfile
@@ -1,5 +1,7 @@
 ARG DOCKER_REGISTRY=docker-registry.data.amsterdam.nl
-FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:latest
+ARG DOCKER_IMAGE_TAG=latest
+
+FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:${DOCKER_IMAGE_TAG}
 
 ARG BUILD_ENV=prod
 

--- a/domains/amsterdamsebos/Dockerfile
+++ b/domains/amsterdamsebos/Dockerfile
@@ -1,5 +1,7 @@
 ARG DOCKER_REGISTRY=docker-registry.data.amsterdam.nl
-FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:latest
+ARG DOCKER_IMAGE_TAG=latest
+
+FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:${DOCKER_IMAGE_TAG}
 
 ARG BUILD_ENV=prod
 

--- a/domains/weesp/Dockerfile
+++ b/domains/weesp/Dockerfile
@@ -1,5 +1,7 @@
 ARG DOCKER_REGISTRY=docker-registry.data.amsterdam.nl
-FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:latest
+ARG DOCKER_IMAGE_TAG=latest
+
+FROM ${DOCKER_REGISTRY}/ois/signalsfrontend:${DOCKER_IMAGE_TAG}
 
 ARG BUILD_ENV=prod
 

--- a/vars/buildAndPushDockerDomainImages.groovy
+++ b/vars/buildAndPushDockerDomainImages.groovy
@@ -1,6 +1,7 @@
-def buildAndPushDockerImage(String dockerBuildArgRegistryHost, String environment, String domain) {
+def buildAndPushDockerImage(String dockerBuildArgRegistryHost, String environment, String domain, String dockerBuildArgImageTag) {
   log.console("building ${domain} ${environment} domain image: ${env.RELEASE_DESCRIPTION}")
   log.console("dockerBuildArgRegistryHost:, ${dockerBuildArgRegistryHost}")
+  log.console("dockerBuildArgImageTag:, ${dockerBuildArgImageTag}")
 
   def environmentAbbreviations = [acceptance: 'acc', production: 'prod']
 
@@ -8,9 +9,10 @@ def buildAndPushDockerImage(String dockerBuildArgRegistryHost, String environmen
     docker.withRegistry(env.DOCKER_REGISTRY_HOST, env.DOCKER_REGISTRY_AUTH) {
       def image = docker.build(
         "ois/signals-${domain}:${env.BUILD_NUMBER}", [
-          "--build-arg DOCKER_REGISTRY=${dockerBuildArgRegistryHost} ",
           '--shm-size 1G ',
           "--build-arg BUILD_ENV=${environmentAbbreviations[environment]} ",
+          "--build-arg DOCKER_REGISTRY=${dockerBuildArgRegistryHost} ",
+          "--build-arg DOCKER_IMAGE_TAG=${dockerBuildArgImageTag} ",
           "${env.WORKSPACE}/signalen/domains/${domain}"
         ].join(' ')
       )

--- a/vars/buildAndPushSignalsFrontendDockerImage.groovy
+++ b/vars/buildAndPushSignalsFrontendDockerImage.groovy
@@ -1,6 +1,8 @@
-def call(String dockerBuildArgRegistryHost, String gitRef, String buildPath = 'signals-frontend') {
+def call(String dockerBuildArgRegistryHost, String gitRef, String dockerBuildArgImageTag = 'latest', String buildPath = 'signals-frontend' ) {
   log.console("building signals-frontend @ ${gitRef}")
   log.console("${env.DOCKER_REGISTRY_HOST} ${env.DOCKER_REGISTRY_AUTH}")
+  log.console("dockerBuildArgRegistryHost:, ${dockerBuildArgRegistryHost}")
+  log.console("dockerBuildArgImageTag:, ${dockerBuildArgImageTag}")
 
   try {
     docker.withRegistry(env.DOCKER_REGISTRY_HOST, env.DOCKER_REGISTRY_AUTH) {
@@ -8,6 +10,7 @@ def call(String dockerBuildArgRegistryHost, String gitRef, String buildPath = 's
         "ois/signalsfrontend:${env.BUILD_NUMBER}", [
           '--shm-size 1G',
           "--build-arg DOCKER_REGISTRY=${dockerBuildArgRegistryHost} ",
+          "--build-arg DOCKER_IMAGE_TAG=${dockerBuildArgRegistryHost} ",
           "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER}",
           "--build-arg GIT_BRANCH=${gitRef}",
           "${env.WORKSPACE}/${buildPath}"
@@ -15,7 +18,7 @@ def call(String dockerBuildArgRegistryHost, String gitRef, String buildPath = 's
       )
 
       signalen.pushImageToDockerRegistry(image)
-      signalen.pushImageToDockerRegistry(image, 'latest')
+      signalen.pushImageToDockerRegistry(image, dockerBuildArgImageTag)
     }
   } catch (Throwable throwable) {
     log.error("build of Docker image signals-frontend ${gitRef} failed")

--- a/vars/signalenAcceptancePipeline.groovy
+++ b/vars/signalenAcceptancePipeline.groovy
@@ -69,7 +69,7 @@ def call(Closure body) {
           buildAndPushSignalsFrontendDockerImage(
             pipelineParams.DOCKER_BUILD_ARG_REGISTRY_HOST,
             pipelineParams.SIGNALS_FRONTEND_BRANCH,
-            'signals-frontend'
+            pipelineParams.DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG
           )
         }
       }
@@ -80,6 +80,7 @@ def call(Closure body) {
             pipelineParams.DOCKER_BUILD_ARG_REGISTRY_HOST,
             pipelineParams.ENVIRONMENT,
             pipelineParams.DOMAINS,
+            pipelineParams.DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG
           )
         }
       }

--- a/vars/signalenReleasePipeline.groovy
+++ b/vars/signalenReleasePipeline.groovy
@@ -107,7 +107,8 @@ def call(Closure body) {
       stage('Build `signals-frontend` Base Image') {
         steps { buildAndPushSignalsFrontendDockerImage(
           pipelineParams.DOCKER_BUILD_ARG_REGISTRY_HOST,
-          params.SIGNALS_FRONTEND_RELEASE_TAG)
+          params.SIGNALS_FRONTEND_RELEASE_TAG,
+          pipelineParams.DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG)
         }
       }
 
@@ -116,7 +117,8 @@ def call(Closure body) {
           buildAndPushDockerDomainImages(
             pipelineParams.DOCKER_BUILD_ARG_REGISTRY_HOST,
             pipelineParams.ENVIRONMENT,
-            targetDomains
+            targetDomains,
+            pipelineParams.DOCKER_BUILD_ARG_DOCKER_IMAGE_TAG
           )
         }
       }


### PR DESCRIPTION
This PR adds a DOCKER_IMAGE_TAG environment variable in order to allow building the application with different versions. Until now only starting the `latest` version was possible.