### PR TITLE
[SIG-3946] Updates auth configuration

### DIFF
--- a/domains/amsterdam/production.config.json
+++ b/domains/amsterdam/production.config.json
@@ -9,9 +9,7 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize"
-  },
-  "keycloak": {
+    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }

--- a/domains/amsterdamsebos/production.config.json
+++ b/domains/amsterdamsebos/production.config.json
@@ -20,9 +20,7 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize"
-  },
-  "keycloak": {
+    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }

--- a/domains/app/production.config.json
+++ b/domains/app/production.config.json
@@ -9,9 +9,7 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize"
-  },
-  "keycloak": {
+    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   },
   "featureFlags": {

--- a/domains/weesp/production.config.json
+++ b/domains/weesp/production.config.json
@@ -40,9 +40,7 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize"
-  },
-  "keycloak": {
+    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }


### PR DESCRIPTION
Because only a single login button is supported, the Keycloak-specific oidc configuration is removed from the JSON schema, and realm is instead defined within the `oidc` key. 