### PR TITLE
[SIG-3952] Hide header in app mode

### DIFF
--- a/domains/app/acceptance.config.json
+++ b/domains/app/acceptance.config.json
@@ -10,5 +10,8 @@
   },
   "oidc": {
     "authEndpoint": "https://acc.api.data.amsterdam.nl/oauth2/authorize"
+  },
+  "featureFlags": {
+    "appMode": true
   }
 }

--- a/domains/app/production.config.json
+++ b/domains/app/production.config.json
@@ -13,5 +13,8 @@
   },
   "keycloak": {
     "realm": "datapunt-ad"
+  },
+  "featureFlags": {
+    "appMode": true
   }
 }


### PR DESCRIPTION
Sets the `appMode` feature flag for the `app` domain.