### PR TITLE
[SIG-3946] Removes AuthZ auth endpoint configuration

### DIFF
--- a/domains/amsterdam/acceptance.config.json
+++ b/domains/amsterdam/acceptance.config.json
@@ -7,8 +7,5 @@
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
   "matomo": {
     "siteId": 14
-  },
-  "oidc": {
-    "authEndpoint": "https://acc.api.data.amsterdam.nl/oauth2/authorize"
   }
 }

--- a/domains/amsterdam/production.config.json
+++ b/domains/amsterdam/production.config.json
@@ -9,7 +9,6 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }

--- a/domains/amsterdamsebos/acceptance.config.json
+++ b/domains/amsterdamsebos/acceptance.config.json
@@ -30,8 +30,5 @@
   },
   "matomo": {
     "siteId": 14
-  },
-  "oidc": {
-    "authEndpoint": "https://acc.api.data.amsterdam.nl/oauth2/authorize"
   }
 }

--- a/domains/amsterdamsebos/production.config.json
+++ b/domains/amsterdamsebos/production.config.json
@@ -20,7 +20,6 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }

--- a/domains/app/acceptance.config.json
+++ b/domains/app/acceptance.config.json
@@ -8,9 +8,6 @@
   "matomo": {
     "siteId": 14
   },
-  "oidc": {
-    "authEndpoint": "https://acc.api.data.amsterdam.nl/oauth2/authorize"
-  },
   "featureFlags": {
     "appMode": true
   }

--- a/domains/app/production.config.json
+++ b/domains/app/production.config.json
@@ -9,7 +9,6 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   },
   "featureFlags": {

--- a/domains/weesp/acceptance.config.json
+++ b/domains/weesp/acceptance.config.json
@@ -47,8 +47,5 @@
   },
   "matomo": {
     "siteId": 14
-  },
-  "oidc": {
-    "authEndpoint": "https://acc.api.data.amsterdam.nl/oauth2/authorize"
   }
 }

--- a/domains/weesp/production.config.json
+++ b/domains/weesp/production.config.json
@@ -40,7 +40,6 @@
     "siteId": 13
   },
   "oidc": {
-    "authEndpoint": "https://api.data.amsterdam.nl/oauth2/authorize",
     "realm": "datapunt-ad"
   }
 }


### PR DESCRIPTION
Removing this key, the `app.amsterdam.json` values (`signals-frontend`) will be used instead: `https://iam.amsterdam.nl/auth`