### PR TITLE
(Chore) Set PR description

### DIFF
--- a/packages/siali/src/lib/release.cli.ts
+++ b/packages/siali/src/lib/release.cli.ts
@@ -185,7 +185,12 @@ export const startRelease = async (version: string, repositoryId: string, releas
   const oid = await releaseService.getLastCommitOid('develop')
 
   await releaseService.createBranch(repositoryId, `refs/heads/release/${version}`, oid)
-  await releaseService.createPullRequest(`Release/${version}`, repositoryId, 'master', `refs/heads/release/${version}`)
+  const mutation: any = await releaseService.createPullRequest(`Release/${version}`, repositoryId, 'master', `refs/heads/release/${version}`)
+
+  const pendingRelease = await loadPendingRelease(releaseService)
+  const release = pendingRelease ? await loadRelease(pendingRelease, releaseService) : undefined
+
+  await releaseService.updateGitHubDescription(mutation.createPullRequest.pullRequest.id, release?.localDescription || '')
 
   await pause()
 }


### PR DESCRIPTION
This PR contains a change to the release command that will provide a PR with a description immediately on creation instead of having to run the `siali release` command twice (once to create the release PR and other time to updated the PR description).