### PR TITLE
(Chore) Domain tag

### DIFF
--- a/vars/buildAndPushSignalsFrontendDockerImage.groovy
+++ b/vars/buildAndPushSignalsFrontendDockerImage.groovy
@@ -1,4 +1,4 @@
-def call(String dockerBuildArgRegistryHost, String environment, String gitRef, String buildPath = 'signals-frontend') {
+def call(String dockerBuildArgRegistryHost, String environment, String frontendGitRef, String domainGitRef = 'develop', String buildPath = 'signals-frontend') {
   log.console("building signals-frontend @ ${gitRef}")
   log.console("${env.DOCKER_REGISTRY_HOST} ${env.DOCKER_REGISTRY_AUTH}")
 
@@ -10,7 +10,8 @@ def call(String dockerBuildArgRegistryHost, String environment, String gitRef, S
           "--build-arg DOCKER_REGISTRY=${dockerBuildArgRegistryHost}",
           "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER}",
           "--build-arg BUILD_ENV=${environment}",
-          "--build-arg GIT_BRANCH=${gitRef}",
+          "--build-arg FRONTEND_TAG=${frontendGitRef}",
+          "--build-arg DOMAIN_TAG=${domainGitRef}",
           "${env.WORKSPACE}/${buildPath}"
         ].join(' ')
       )

--- a/vars/signalenReleasePipeline.groovy
+++ b/vars/signalenReleasePipeline.groovy
@@ -108,7 +108,8 @@ def call(Closure body) {
         steps { buildAndPushSignalsFrontendDockerImage(
           pipelineParams.DOCKER_BUILD_ARG_REGISTRY_HOST,
           pipelineParams.ENVIRONMENT,
-          params.SIGNALS_FRONTEND_RELEASE_TAG)
+          params.SIGNALS_FRONTEND_RELEASE_TAG,
+          params.SIGNALEN_RELEASE_TAG,)
         }
       }
 


### PR DESCRIPTION
This PR contains changes to the release pipeline which exposes the `DOMAIN_TAG` Docker build argument and renames the `GIT_BRANCH` argument to `FRONTEND_TAG`.

See also https://github.com/Amsterdam/signals-frontend/pull/1848.