### PR TITLE
[SIG-4370] Enable extra questions Weesp

### DIFF
--- a/domains/weesp/acceptance.config.json
+++ b/domains/weesp/acceptance.config.json
@@ -1,6 +1,5 @@
 {
   "featureFlags": {
-    "fetchQuestionsFromBackend": true,
     "showThorButton": true
   },
   "language": {

--- a/domains/weesp/production.config.json
+++ b/domains/weesp/production.config.json
@@ -1,6 +1,5 @@
 {
   "featureFlags": {
-    "fetchQuestionsFromBackend": true,
     "showThorButton": true
   },
   "language": {


### PR DESCRIPTION
Enables showing extra questions for Weesp, equal to the ones used for the Amsterdam domain.