### PR TITLE
[SIG-4488] Boundingbox for weesp same as Amsterdam

### DIFF
--- a/domains/weesp/acceptance.config.json
+++ b/domains/weesp/acceptance.config.json
@@ -24,12 +24,8 @@
     "smallHeight": "32px"
   },
   "map": {
-    "municipality": "weesp",
+    "municipality": ["weesp", "amsterdam", "ouder-amstel"],
     "options": {
-      "maxBounds": [
-        [52.274583, 4.959873],
-        [52.338832, 5.156252]
-      ],
       "center": [52.3107404, 5.0322487],
       "zoom": 10,
       "maxZoom": 14,


### PR DESCRIPTION
- Expand bounding box Weesp to also include Amsterdam
- Add amsterdam and ouder-amstel address fields