### PR TITLE
chore: set assignSignalToDepartment to false

### DIFF
--- a/domains/amsterdam/acceptance.config.json
+++ b/domains/amsterdam/acceptance.config.json
@@ -1,7 +1,6 @@
 {
   "featureFlags": {
-    "showThorButton": true,
-    "assignSignalToDepartment": true
+    "showThorButton": true
   },
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl"
 }


### PR DESCRIPTION
Disabling assignSignalToDepartment since we are not using it. 